### PR TITLE
Implement custom tooltip styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,25 +40,29 @@
                 <md-icon>menu</md-icon>
                 <md-icon slot="selected">menu_open</md-icon>
             </md-icon-button>
+            <md-tooltip for="menuBtn" id="menuTooltip">メニューを開く</md-tooltip>
             <div class="container mx-auto px-6 py-4">
                 <h1 class="text-2xl font-bold text-primary">
                     マイポートフォリオ
                 </h1>
             </div>
-            <md-icon-button class="mx-2" title="検索">
+            <md-icon-button class="mx-2" id="searchBtn" title="検索">
                 <md-icon>search</md-icon>
             </md-icon-button>
+            <md-tooltip for="searchBtn" id="searchTooltip">検索</md-tooltip>
             <md-icon-button class="mx-2" id="themeBtn" title="ダークモードに切り替える">
                 <md-icon>dark_mode</md-icon>
                 <md-icon slot="selected">light_mode</md-icon>
             </md-icon-button>
+            <md-tooltip for="themeBtn" id="themeTooltip">ダークモードに切り替える</md-tooltip>
         </header>
 
         <main class="container mx-auto px-6 py-8">
             <!-- FAB [↑] -->
-            <md-fab class="fab-pagetop" variant="primary">
+            <md-fab class="fab-pagetop" id="pageTopFab" variant="primary">
                 <md-icon slot="icon">arrow_upward</md-icon>
             </md-fab>
+            <md-tooltip for="pageTopFab" id="pageTopTooltip">ページトップへ</md-tooltip>
             <section
                 id="hero"
                 class="bg-card rounded-xl shadow-xl p-8 md:p-12 mb-12 text-center"

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // メニューアイコンボタン
     const menuBtn = document.getElementById('menuBtn');
+    const menuTooltip = document.getElementById('menuTooltip');
     if (menuBtn) {
         menuBtn.addEventListener('click', () => {
             // selected属性をトグル
@@ -26,14 +27,17 @@ document.addEventListener('DOMContentLoaded', function () {
             // ツールチップも状態に応じて変更
             if (menuBtn.hasAttribute('selected')) {
                 menuBtn.setAttribute('title', 'メニューを閉じる');
+                if (menuTooltip) menuTooltip.textContent = 'メニューを閉じる';
             } else {
                 menuBtn.setAttribute('title', 'メニューを開く');
+                if (menuTooltip) menuTooltip.textContent = 'メニューを開く';
             }
         });
     }
 
     // テーマ切り替えボタン
     const themeBtn = document.getElementById('themeBtn');
+    const themeTooltip = document.getElementById('themeTooltip');
     const themeStyle = document.getElementById('theme-style');
     if (themeBtn && themeStyle) {
         const linkElem = document.getElementById('theme-style');
@@ -43,9 +47,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (themeBtn.hasAttribute('selected')) {
                     linkElem.setAttribute('href', 'style-dark.css');
                     themeBtn.setAttribute('title', 'ライトモードに切り替える');
+                    if (themeTooltip) themeTooltip.textContent = 'ライトモードに切り替える';
                 } else {
                     linkElem.setAttribute('href', 'style-light.css');
                     themeBtn.setAttribute('title', 'ダークモードに切り替える');
+                    if (themeTooltip) themeTooltip.textContent = 'ダークモードに切り替える';
                 }
             }
         });
@@ -58,10 +64,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 themeStyle.setAttribute('href', 'style-dark.css');
                 themeBtn.setAttribute('selected', '');
                 themeBtn.setAttribute('title', 'ライトモードに切り替える');
+                if (themeTooltip) themeTooltip.textContent = 'ライトモードに切り替える';
             } else {
                 themeStyle.setAttribute('href', 'style-light.css');
                 themeBtn.removeAttribute('selected');
                 themeBtn.setAttribute('title', 'ダークモードに切り替える');
+                if (themeTooltip) themeTooltip.textContent = 'ダークモードに切り替える';
             }
         }
         applySystemTheme();

--- a/style-dark.css
+++ b/style-dark.css
@@ -86,11 +86,12 @@ body {
     z-index: 50;
 }
 
-/* .tooltip, [role="tooltip"] {
+.tooltip,
+[role="tooltip"] {
     background: var(--md-sys-color-surface-variant);
     color: var(--md-sys-color-on-surface-variant);
     border-radius: 16px;
     padding: 0.5em 1em;
     font-size: 0.95em;
     box-shadow: 0 2px 8px rgba(255, 255, 255, 0.8);
-} */
+}

--- a/style-light.css
+++ b/style-light.css
@@ -86,11 +86,12 @@ body {
     z-index: 50;
 }
 
-/* .tooltip, [role="tooltip"] {
+.tooltip,
+[role="tooltip"] {
     background: var(--md-sys-color-surface-variant);
     color: var(--md-sys-color-on-surface-variant);
     border-radius: 16px;
     padding: 0.5em 1em;
     font-size: 0.95em;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-} */
+}


### PR DESCRIPTION
## Summary
- add Material Web tooltips for icon buttons and page top FAB
- support tooltip text updates in JS
- enable themed tooltip styles

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa1a79b10833185e93e3d27097329